### PR TITLE
Use https:// instead of git:// in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/observable"]
 	path = lib/observable
-	url = git://github.com/js-coder/observable.git
+	url = https://github.com/js-coder/observable.git


### PR DESCRIPTION
to make x18n usable as a submodule in gh-pages projects.
GitHub Pages cannot clone submodules via git://