### PR TITLE
Added bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,16 @@
+{
+  "name": "x18n",
+  "version": "1.0.3",
+  "homepage": "https://github.com/js-coder/x18n",
+  "main": "lib/x18n.js",
+  "ignore": [
+    "**/.*",
+    "**/*.coffee",
+    "grunt.js",
+    "History.md",
+    "node_modules",
+    "bower_components",
+    "spec",
+    "testem.yml"
+  ]
+}


### PR DESCRIPTION
Added a `bower.json` where explicitely define the `main` file and filter out any unneeded file, including `.coffee` sources.

Without this cannot require this library with [sprockets](https://github.com/sstephenson/sprockets) because both the `.js` and the `.coffee` are included in the package.
