### PR TITLE
Fix observable_js library name to work with es6 + webpack

### DIFF
--- a/lib/x18n.js
+++ b/lib/x18n.js
@@ -189,7 +189,7 @@
     Observable = require('observable_js');
     module.exports = base(Observable);
   } else if (typeof define === 'function' && define.amd) {
-    define('x18n', ['observable'], function(Observable) {
+    define('x18n', ['observable_js'], function(Observable) {
       return base(Observable);
     });
   } else {


### PR DESCRIPTION
We tried using it in our project but the import was failing. Simply matching the key to the correct folder named fixed it.